### PR TITLE
fix: cleanup on start failure and fix actor isolation

### DIFF
--- a/bridge/swift/TonePhoneCore.swift
+++ b/bridge/swift/TonePhoneCore.swift
@@ -305,6 +305,7 @@ public final class TonePhoneCore {
             tp_set_event_callback(nil, nil)
             tp_shutdown()
             isInitialized = false
+            coreState = .idle
             throw TonePhoneError(from: startResult)
         }
     }


### PR DESCRIPTION
Follow-up to #27 addressing CodeRabbit review comments.

## Summary
- Roll back initialization state if `tp_start()` fails after `tp_init()` succeeds
  - Call `tp_set_event_callback(nil, nil)` to unregister callback
  - Call `tp_shutdown()` to clean up bridge resources
  - Reset `isInitialized = false` to allow retries
- Fix actor isolation violation in C event callback
  - Mark `handleEvent` as `nonisolated` since it's called from baresip's event thread
  - Use `Task { @MainActor in }` instead of `DispatchQueue.main.async` for proper Swift concurrency

## Test plan
- [ ] Verify start failure properly cleans up and allows retry
- [ ] Verify events still dispatch to main thread correctly
- [ ] Verify no actor isolation warnings under strict concurrency checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery on startup with proper cleanup and state reset.

* **Refactor**
  * Reworked event handling and dispatch to ensure thread-safe main-thread updates and more robust state management.
  * Expanded event processing to support additional event types (account, call, media).

* **Documentation**
  * Added comments clarifying the new threading and event-handling model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->