### PR TITLE
Fix call history not recording after calls end

### DIFF
--- a/apps/macOS/TonePhone/AppViewModel.swift
+++ b/apps/macOS/TonePhone/AppViewModel.swift
@@ -128,6 +128,8 @@ final class AppViewModel: ObservableObject {
         var isOutgoing: Bool = false
         /// The account that owns this call (for history recording).
         var ownerAccountID: UUID?
+        /// Whether this call has already been recorded in history.
+        var historyRecorded: Bool = false
     }
 
     /// All active calls tracked by ID.
@@ -330,6 +332,10 @@ final class AppViewModel: ObservableObject {
 
         switch state {
         case .idle:
+            // Record in call history if not already recorded via .ended
+            if callInfo.remoteURI != nil {
+                recordCallHistory(callInfo)
+            }
             // Remove from active calls
             activeCalls.removeValue(forKey: callID)
             // Ensure ringtone and notification are stopped
@@ -403,6 +409,9 @@ final class AppViewModel: ObservableObject {
 
         case .ended(let reason):
             callInfo.state = .ended(reason: reason)
+            // Record in call history
+            recordCallHistory(callInfo)
+            callInfo.historyRecorded = true
             activeCalls[callID] = callInfo
             // Stop ringtone and remove notification
             IncomingCallManager.shared.handleCallEnded()
@@ -410,8 +419,6 @@ final class AppViewModel: ObservableObject {
                 callState = .ended(reason: reason)
                 stopCallDurationTimer()
             }
-            // Record in call history
-            recordCallHistory(callInfo)
             scheduleCallCleanup(callID: callID, delay: 1.5)
         }
     }
@@ -520,6 +527,7 @@ final class AppViewModel: ObservableObject {
 
     /// Records a completed call in the call history.
     private func recordCallHistory(_ callInfo: CallInfo) {
+        guard !callInfo.historyRecorded else { return }
         guard let accountID = callInfo.ownerAccountID ?? activeAccount?.id else { return }
 
         let direction: CallDirection
@@ -968,7 +976,8 @@ final class AppViewModel: ObservableObject {
                     state: .outgoing,
                     remoteURI: uri,
                     remoteName: self.parseDisplayName(from: uri),
-                    isOutgoing: true
+                    isOutgoing: true,
+                    ownerAccountID: self.activeAccount?.id
                 )
                 self.activeCalls[callID] = callInfo
 


### PR DESCRIPTION
## Summary

- Calls that transition directly to `.idle` (skipping `.ended`) were not being recorded in call history — this is the common path for cancelled outgoing calls and some server configurations
- Added history recording in `.idle` state handler in addition to `.ended`
- Added `historyRecorded` flag on `CallInfo` to prevent duplicate entries when both `.ended` and `.idle` fire
- Set `ownerAccountID` in `makeCall()` so outgoing calls are always bound to the correct account

## Test plan

- [ ] Make an outgoing call, let it ring, hang up — verify it appears in Recents
- [ ] Make an outgoing call, let it connect, hang up — verify it appears in Recents
- [ ] Receive an incoming call, answer, hang up — verify it appears in Recents
- [ ] Receive an incoming call, decline — verify it appears as missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call history tracking to ensure records are reliably captured across all call scenarios.
  * Eliminated duplicate call history entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->